### PR TITLE
Add rule for Pod (un)readiness and alarm to Slack

### DIFF
--- a/alertmanager/alertmanager.yaml
+++ b/alertmanager/alertmanager.yaml
@@ -1,0 +1,29 @@
+global:
+  resolve_timeout: 5m
+  slack_api_url: ''
+route:
+  group_by: ['alertname', 'cluster', 'service']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 1h
+  receiver: default-receiver
+  routes:
+  - match:
+      alertname: DeadMansSwitch
+    receiver: 'null'
+receivers:
+- name: 'default-receiver'
+  slack_configs:
+  - channel: '#alerts'
+    title: '[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] Prometehus Event Notification'
+    text: >-
+        {{ range .Alerts }}
+           *Alert:* {{ .Annotations.summary }} - `{{ .Labels.severity }}`
+          *Description:* {{ .Annotations.description }}
+          *Graph:* <{{ .GeneratorURL }}|:chart_with_upwards_trend:> *Runbook:* <{{ .Annotations.runbook }}|:spiral_note_pad:>
+          *Details:*
+          {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
+          {{ end }}
+        {{ end }}
+    send_resolved: true
+- name: 'null'

--- a/alertmanager/alertmanager.yaml
+++ b/alertmanager/alertmanager.yaml
@@ -2,7 +2,7 @@ global:
   resolve_timeout: 5m
   slack_api_url: ''
 route:
-  group_by: ['alertname', 'cluster', 'service']
+  group_by: ['alertname', 'cluster', 'service', 'deployment', 'namespace']
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 1h

--- a/alertmanager/alertmanager.yaml
+++ b/alertmanager/alertmanager.yaml
@@ -15,7 +15,11 @@ receivers:
 - name: 'default-receiver'
   slack_configs:
   - channel: '#alerts'
-    title: '[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] Prometehus Event Notification'
+    title: >-
+        [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}]
+        {{ range .Alerts }}
+        {{ .Annotations.summary }}
+        {{ end }}
     text: >-
         {{ range .Alerts }}
            *Alert:* {{ .Annotations.summary }} - `{{ .Labels.severity }}`

--- a/alertmanager/update.sh
+++ b/alertmanager/update.sh
@@ -11,9 +11,7 @@ kctl() {
     kubectl --namespace "$NAMESPACE" "$@"
 }
 
-SECRET=prometheus-custom
+SECRET=alertmanager-main
 
-kctl create secret generic $SECRET --from-file $DIR/config/prometheus.yaml --dry-run -o=yaml \
-  | kctl replace secret $SECRET -f - \
-  && kctl scale --replicas=0 statefulset prometheus-custom \
-  && kctl scale --replicas=1 statefulset prometheus-custom
+kctl create secret generic $SECRET --from-file $DIR/alertmanager.yaml --dry-run -o=yaml \
+  | kctl replace secret $SECRET -f -

--- a/alertmanager/update.sh
+++ b/alertmanager/update.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+set -x
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ -z "${NAMESPACE}" ]; then
+    NAMESPACE=monitoring
+fi
+
+kctl() {
+    kubectl --namespace "$NAMESPACE" "$@"
+}
+
+SECRET=prometheus-custom
+
+kctl create secret generic $SECRET --from-file $DIR/config/prometheus.yaml --dry-run -o=yaml \
+  | kctl replace secret $SECRET -f - \
+  && kctl scale --replicas=0 statefulset prometheus-custom \
+  && kctl scale --replicas=1 statefulset prometheus-custom

--- a/custom-prometheus/config.sh
+++ b/custom-prometheus/config.sh
@@ -14,6 +14,4 @@ kctl() {
 SECRET=prometheus-custom
 
 kctl create secret generic $SECRET --from-file $DIR/config/prometheus.yaml --dry-run -o=yaml \
-  | kctl replace secret $SECRET -f - \
-  && kctl scale --replicas=0 statefulset prometheus-custom \
-  && kctl scale --replicas=1 statefulset prometheus-custom
+  | kctl replace secret $SECRET -f -

--- a/k8s-rules-apply.sh
+++ b/k8s-rules-apply.sh
@@ -14,6 +14,3 @@ kctl() {
 SECRET=prometheus-custom
 
 $DIR/k8s-rules-generate.sh | kctl replace -f -
-
-# assuming port-forward
-curl -v -X POST http://localhost:9090/-/reload

--- a/k8s-rules-apply.sh
+++ b/k8s-rules-apply.sh
@@ -13,7 +13,7 @@ kctl() {
 
 SECRET=prometheus-custom
 
-$DIR/k8s-rules-generate.sh | kctl apply -f -
+$DIR/k8s-rules-generate.sh | kctl replace -f -
 
 # assuming port-forward
 curl -v -X POST http://localhost:9090/-/reload

--- a/k8s-rules-apply.sh
+++ b/k8s-rules-apply.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+set -x
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ -z "${NAMESPACE}" ]; then
+    NAMESPACE=monitoring
+fi
+
+kctl() {
+    kubectl --namespace "$NAMESPACE" "$@"
+}
+
+SECRET=prometheus-custom
+
+$DIR/k8s-rules-generate.sh | kctl apply -f -
+
+# assuming port-forward
+curl -v -X POST http://localhost:9090/-/reload

--- a/k8s-rules-generate.sh
+++ b/k8s-rules-generate.sh
@@ -4,7 +4,7 @@ cd kube-prometheus
 . hack/scripts/generate-rules-configmap.sh
 cd ..
 
-for f in rules/*.rules.yaml
+for f in k8s-yolean-rules/*.y*ml
 do
   echo "  $(basename $f): |+"
   cat $f | sed "s/^/    /g"

--- a/k8s-yolean-rules/pod-unavailable.yml
+++ b/k8s-yolean-rules/pod-unavailable.yml
@@ -1,0 +1,10 @@
+groups:
+- name: ./yolean.availability.rules
+  rules:
+  - alert: AvailabilityCheckFailed
+    expr: kube_deployment_status_replicas_available / kube_deployment_spec_replicas < 1
+    for: 0 # TODO 1m or 30s is maybe more reasonable
+    labels:
+      severity: critical
+    annotations:
+      summary: Pod is down!

--- a/k8s-yolean-rules/pod-unavailable.yml
+++ b/k8s-yolean-rules/pod-unavailable.yml
@@ -11,4 +11,4 @@ groups:
     labels:
       severity: critical
     annotations:
-      summary: "*{{ $value }}%* of *{{ $labels.deployment }}[{{ $labels.namespace }}]* available"
+      summary: "{{ $value }}% of {{ $labels.deployment }}[{{ $labels.namespace }}] available"

--- a/k8s-yolean-rules/pod-unavailable.yml
+++ b/k8s-yolean-rules/pod-unavailable.yml
@@ -3,7 +3,7 @@ groups:
   rules:
   - alert: AvailabilityCheckFailed
     expr: kube_deployment_status_replicas_available / kube_deployment_spec_replicas < 1
-    for: 0 # TODO 1m or 30s is maybe more reasonable
+    for: 5s
     labels:
       severity: critical
     annotations:

--- a/k8s-yolean-rules/pod-unavailable.yml
+++ b/k8s-yolean-rules/pod-unavailable.yml
@@ -2,9 +2,13 @@ groups:
 - name: ./yolean.availability.rules
   rules:
   - alert: AvailabilityCheckFailed
-    expr: kube_deployment_status_replicas_available / kube_deployment_spec_replicas < 1
-    for: 5s
+    expr: "(kube_deployment_status_replicas_available / kube_deployment_spec_replicas) * 100 < 100"
+    # NOTE This seems to be optional, thus missing should equal 0 ?
+    # for: 5s
+    # NOTE:
+    # Both labels and annotations support templates:
+    # https://prometheus.io/docs/alerting/rules/#templating
     labels:
       severity: critical
     annotations:
-      summary: Pod is down!
+      summary: "*{{ $value }}%* of *{{ $labels.deployment }}[{{ $labels.namespace }}]* available"


### PR DESCRIPTION
Only `deployment` so far, `statefulset` is TODO, but this PR is primarily an example for rules management and alertmanager config.
