### PR TITLE
Add a Grafana setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ start from the example kustomize base:
 
 ```
 kubectl apply -k example-small
+kubectl -n monitoring create -k kubernetes-mixin-dashboards
+kubectl apply -k grafana
 ```
 
 Note how [Prometheus](./example-small/now-prometheus.yaml) will match rules and monitors

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ start from the example kustomize base:
 kubectl apply -k example-small
 ```
 
-Note how [Prometheus](./example-small/main-prometheus.yaml) will match rules and monitors
+Note how [Prometheus](./example-small/now-prometheus.yaml) will match rules and monitors
 using the label(s) that the [kustomization.yaml](./example-small/kustomization.yaml) adds.
 
 ## Re-generate stuff

--- a/base-label-prometheus-now/kustomization.yaml
+++ b/base-label-prometheus-now/kustomization.yaml
@@ -1,7 +1,7 @@
 # The resources to be scraped are versioned without the labels that Prometheus Operator matches on
 # so the purpose of this kustomize base is to collect them and set a chosen label
 commonLabels:
-  prometheus: main
+  prometheus: now
 bases:
 - ../k8s
 - ../node-exporter

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -37,7 +37,7 @@ services:
       generatorOptions:
         disableNameSuffixHash: true
       configMapGenerator:
-      - name: kubernets-mixin-grafana-dashboards
+      - name: kubernetes-mixin-grafana-dashboards
         files:
       EOF
       find /dashboards-kustomize-base -name \*.json | sed 's|.*/\(.*\)|  - \1=\1|' >> /dashboards-kustomize-base/kustomization.yaml

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -40,7 +40,7 @@ services:
       - name: kubernets-mixin-grafana-dashboards
         files:
       EOF
-      find dashboards_out -name \*.json | sed 's|dashboards_out/\(.*\)|  - \1=\1|' >> /dashboards-kustomize-base/kustomization.yaml
+      find /dashboards-kustomize-base -name \*.json | sed 's|.*/\(.*\)|  - \1=\1|' >> /dashboards-kustomize-base/kustomization.yaml
     volumes:
     - ./kubernetes-mixin:/kustomize-base
     - ./kubernetes-mixin-dashboards:/dashboards-kustomize-base

--- a/example-small/kustomization.yaml
+++ b/example-small/kustomization.yaml
@@ -1,14 +1,14 @@
 namespace: monitoring
 bases:
 - ../rbac-prometheus
-- ../base-label-prometheus-main
+- ../base-label-prometheus-now
 # Needs separate kubectl replace -k
 #- ../kubernetes-mixin-dashboards
 resources:
 - main-alertmanager-service.yaml
 - main-alertmanager.yaml
-- main-prometheus-service.yaml
-- main-prometheus.yaml
+- now-prometheus-service.yaml
+- now-prometheus.yaml
 generatorOptions:
   disableNameSuffixHash: true
 secretGenerator:

--- a/example-small/kustomization.yaml
+++ b/example-small/kustomization.yaml
@@ -7,6 +7,7 @@ bases:
 resources:
 - main-alertmanager-service.yaml
 - main-alertmanager.yaml
+- main-prometheus-service.yaml
 - main-prometheus.yaml
 generatorOptions:
   disableNameSuffixHash: true

--- a/example-small/main-prometheus-service.yaml
+++ b/example-small/main-prometheus-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-main
+spec:
+  ports:
+  - name: web
+    port: 9090
+    protocol: TCP
+    targetPort: web
+  selector:
+    app: prometheus
+    prometheus: main

--- a/example-small/now-prometheus-service.yaml
+++ b/example-small/now-prometheus-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: prometheus-main
+  name: prometheus-now
 spec:
   ports:
   - name: web
@@ -10,4 +10,4 @@ spec:
     targetPort: web
   selector:
     app: prometheus
-    prometheus: main
+    prometheus: now

--- a/example-small/now-prometheus.yaml
+++ b/example-small/now-prometheus.yaml
@@ -1,9 +1,10 @@
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
-  name: main
+  name: now
 spec:
   replicas: 1
+  retention: 2h
   serviceAccountName: prometheus
   alerting:
     alertmanagers:
@@ -12,10 +13,10 @@ spec:
       port: web
   serviceMonitorSelector:
     matchLabels:
-      prometheus: main
+      prometheus: now
   podMonitorSelector:
     matchLabels:
-      prometheus: main
+      prometheus: now
   ruleSelector:
     matchLabels:
-      prometheus: main
+      prometheus: now

--- a/example-small/now-prometheus.yaml
+++ b/example-small/now-prometheus.yaml
@@ -6,6 +6,11 @@ spec:
   replicas: 1
   retention: 2h
   serviceAccountName: prometheus
+  image: prom/prometheus:v2.18.1@sha256:5880ec936055fad18ccee798d2a63f64ed85bd28e8e0af17c6923a090b686c3d
+  securityContext:
+    runAsUser: 65534
+    runAsGroup: 65534
+    fsGroup: 65534
   alerting:
     alertmanagers:
     - namespace: monitoring

--- a/example-small/now-prometheus.yaml
+++ b/example-small/now-prometheus.yaml
@@ -10,7 +10,8 @@ spec:
   securityContext:
     runAsUser: 65534
     runAsGroup: 65534
-    fsGroup: 65534
+    # Uncomment on failure to start a new instance. Left out because it may have performance implications, as configmaps may be large.
+    #fsGroup: 65534
   alerting:
     alertmanagers:
     - namespace: monitoring

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,0 +1,3 @@
+# Grafana as Kustomize base
+
+Adapted from https://github.com/utilitywarehouse/grafana-manifests.

--- a/grafana/config-dashboards.yaml
+++ b/grafana/config-dashboards.yaml
@@ -1,0 +1,16 @@
+apiVersion: 1
+providers:
+- name: 'opensource'
+  folder: ''
+  type: file
+  disableDeletion: false
+  editable: true
+  options:
+    path: /dashboards/opensource/repo
+- name: 'kubernets-mixin'
+  folder: ''
+  type: file
+  disableDeletion: false
+  editable: true
+  options:
+    path: /dashboards/kubernetes-mixin

--- a/grafana/config-datasources.yaml
+++ b/grafana/config-datasources.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+datasources:
+- name: Prometheus now
+  type: prometheus
+  #access: proxy
+  url: http://prometheus-now:9090
+  basicAuth: false
+  isDefault: true
+  version: 1
+  editable: false
+  jsonData: 
+    timeInterval: "30s"

--- a/grafana/grafana-deployment.yaml
+++ b/grafana/grafana-deployment.yaml
@@ -1,0 +1,122 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+      - name: grafana
+        image: grafana/grafana:7.0.0-ubuntu@sha256:d4fe3f23dcf9e106419eed2573607fa09e5160475ac4e9ba9021f8f79073efba
+        env:
+        # Has to be a kustomization
+        # - name: GF_SERVER_ROOT_URL
+        #   value: https://demo-grafana.com
+        - name: GF_PATHS_DATA
+          value: /data
+        - name: GF_PATHS_PLUGINS
+          value: /data/plugins
+        - name: GF_PATHS_PROVISIONING
+          value: /provisioning
+        - name: GF_SECURITY_ALLOW_EMBEDDING
+          value: "true"
+        # - name: GF_SECURITY_ADMIN_PASSWORD
+        #   valueFrom:
+        #     secretKeyRef:
+        #       key: admin-password
+        #       name: grafana-secrets
+        - name: GF_USERS_AUTO_ASSIGN_ORG_ROLE
+          value: "Admin"
+        - name: GF_USERS_ALLOW_SIGN_UP
+          value: "false"
+        - name: GF_USERS_ALLOW_ORG_CREATE
+          value: "false"
+        - name: GF_AUTH_DISABLE_LOGIN_FORM
+          value: "true"
+        - name: GF_AUTH_ANONYMOUS_ENABLED
+          value: "true"
+        - name: GF_ANALYTICS_REPORTING_ENABLED
+          value: "false"
+        - name: GF_ALERTING_ENABLED
+          value: "false"
+        - name: GF_SMTP_ENABLED
+          value: "false"
+        - name: GF_LOG_MODE
+          value: console
+        # - name: GF_INSTALL_PLUGINS
+        #   value: grafana-piechart-panel,grafana-clock-panel
+        - name: GF_SERVER_ENABLE_GZIP
+          value: "true"
+        - name: GF_METRICS_ENABLED
+          value: "true"
+        - name: GF_EXPLORE_ENABLED
+          value: "true"
+        ports:
+        - containerPort: 3000
+          name: web
+          protocol: TCP
+        resources:
+          requests:
+            cpu: "0"
+            memory: 100Mi
+          limits:
+            memory: 1000Mi
+        livenessProbe:
+          httpGet:
+            path: /api/health
+            port: web
+            scheme: HTTP
+        readinessProbe:
+          httpGet:
+            path: /api/health
+            port: web
+            scheme: HTTP
+        volumeMounts:
+        - mountPath: /data
+          name: data
+        - mountPath: /provisioning
+          name: grafana
+        - mountPath: /dashboards
+          name: dashboards
+        - mountPath: /dashboards/kubernetes-mixin
+          name: kubernetes-mixin-grafana-dashboards
+      - name: git-sync
+        image: k8s.gcr.io/git-sync:v3.1.6
+        env:
+        - name: GIT_SYNC_REPO
+          value: "https://github.com/Yolean/grafana-dashboards"
+        - name: GIT_SYNC_DEST
+          value: "repo"
+        - name: GIT_SYNC_ROOT
+          value: "/dashboards/opensource"
+        - name: GIT_SYNC_MAX_SYNC_FAILURES
+          value: "5"
+        securityContext:
+          runAsUser: 65533 # git-sync user
+        volumeMounts:
+        - mountPath: /dashboards
+          name: dashboards
+      volumes:
+      - emptyDir: {}
+        name: data
+      - configMap:
+          items:
+          - key: dashboards.yaml
+            path: dashboards/dashboards.yaml
+          - key: datasources.yaml
+            path: datasources/datasources.yaml
+          name: grafana
+        name: grafana
+      - emptyDir: {}
+        name: dashboards
+      - name: kubernetes-mixin-grafana-dashboards
+        configMap:
+          name: kubernetes-mixin-grafana-dashboards
+          optional: true

--- a/grafana/grafana-deployment.yaml
+++ b/grafana/grafana-deployment.yaml
@@ -50,14 +50,18 @@ spec:
           value: "false"
         - name: GF_LOG_MODE
           value: console
-        # - name: GF_INSTALL_PLUGINS
-        #   value: grafana-piechart-panel,grafana-clock-panel
+        - name: GF_INSTALL_PLUGINS
+          value: grafana-image-renderer,grafana-piechart-panel,grafana-clock-panel
         - name: GF_SERVER_ENABLE_GZIP
           value: "true"
         - name: GF_METRICS_ENABLED
           value: "true"
         - name: GF_EXPLORE_ENABLED
           value: "true"
+        - name: GF_RENDERING_SERVER_URL
+          value: http://127.0.0.1:8081/render
+        - name: GF_RENDERING_CALLBACK_URL
+          value: http://127.0.0.1:3000/
         ports:
         - containerPort: 3000
           name: web
@@ -87,6 +91,16 @@ spec:
           name: dashboards
         - mountPath: /dashboards/kubernetes-mixin
           name: kubernetes-mixin-grafana-dashboards
+      # renderer should be a separate deployment to allow scale out, but so far we're just testing it
+      - name: renderer
+        image: grafana/grafana-image-renderer:2.0.0@sha256:e2aa271b92c3c57b5e327c772d70595299216f9481bf65ca3f2d508bedccab7c
+        env:
+        - name: ENABLE_METRICS
+          value: "true"
+        ports:
+        - containerPort: 8081
+          name: renderer
+          protocol: TCP
       - name: git-sync
         image: k8s.gcr.io/git-sync:v3.1.6
         env:

--- a/grafana/grafana-service.yaml
+++ b/grafana/grafana-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    traefik.ingress.kubernetes.io/affinity: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "3000"
+    prometheus.io/scrape: "true"
+  labels:
+    name: grafana
+  name: grafana
+spec:
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 10800
+  ports:
+  - name: grafana
+    port: 3000
+    protocol: TCP
+    targetPort: 3000
+  selector:
+    app: grafana

--- a/grafana/kustomization.yaml
+++ b/grafana/kustomization.yaml
@@ -1,5 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: monitoring
-bases:
-# While this is WIP we have a branch https://github.com/Yolean/grafana-manifests/tree/example-mod
-#- github.com/Yolean/grafana-manifests/example?ref=fd42490613a580c0b0b96ee780c7b89ae47fdb7f
-- ../../grafana-manifests/example
+resources:
+- grafana-service.yaml
+- grafana-deployment.yaml
+configMapGenerator:
+- name: grafana
+  files:
+  - datasources.yaml=config-datasources.yaml
+  - dashboards.yaml=config-dashboards.yaml

--- a/grafana/kustomization.yaml
+++ b/grafana/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace: monitoring
+bases:
+# While this is WIP we have a branch https://github.com/Yolean/grafana-manifests/tree/example-mod
+- github.com/Yolean/grafana-manifests/example?ref=fd42490613a580c0b0b96ee780c7b89ae47fdb7f

--- a/grafana/kustomization.yaml
+++ b/grafana/kustomization.yaml
@@ -1,4 +1,5 @@
 namespace: monitoring
 bases:
 # While this is WIP we have a branch https://github.com/Yolean/grafana-manifests/tree/example-mod
-- github.com/Yolean/grafana-manifests/example?ref=fd42490613a580c0b0b96ee780c7b89ae47fdb7f
+#- github.com/Yolean/grafana-manifests/example?ref=fd42490613a580c0b0b96ee780c7b89ae47fdb7f
+- ../../grafana-manifests/example

--- a/kubernetes-mixin-dashboards/kustomization.yaml
+++ b/kubernetes-mixin-dashboards/kustomization.yaml
@@ -20,7 +20,6 @@ configMapGenerator:
   - k8s-resources-node.json=k8s-resources-node.json
   - k8s-resources-pod.json=k8s-resources-pod.json
   - namespace-by-workload.json=namespace-by-workload.json
-  - controller-manager.json=controller-manager.json
   - pod-total.json=pod-total.json
   - persistentvolumesusage.json=persistentvolumesusage.json
   - k8s-resources-workloads-namespace.json=k8s-resources-workloads-namespace.json

--- a/kubernetes-mixin-dashboards/kustomization.yaml
+++ b/kubernetes-mixin-dashboards/kustomization.yaml
@@ -4,7 +4,7 @@
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:
-- name: kubernets-mixin-grafana-dashboards
+- name: kubernetes-mixin-grafana-dashboards
   files:
   - namespace-by-pod.json=namespace-by-pod.json
   - k8s-resources-cluster.json=k8s-resources-cluster.json


### PR DESCRIPTION
based on https://github.com/Yolean/grafana-manifests/tree/example-mod

The image renderer is untested because I don't have a use case for it now. I'm interested in how the chrome headless browser works in kubernetes, i.e. what container options will be needed. If there's a need to fiddle with security aspects it should definitely move to a separate deployment.