### PR TITLE
Final development version of the devloop.

### DIFF
--- a/runtime-nodejs/jest.kubernetes-assertions-reporter.js
+++ b/runtime-nodejs/jest.kubernetes-assertions-reporter.js
@@ -8,6 +8,7 @@ const ASSERT_IS_DEV = process.env.ASSERT_IS_DEV === 'true';
 const client = require('prom-client');
 const register = client.register;
 
+
 const assertions_failed = new client.Gauge({
   name: 'assertions_failed',
   help: 'current numFailingTests incrementally aggregated per run per path',
@@ -47,6 +48,8 @@ class SpecFilesTracker {
 
   constructor() {
     this._pathsSeen = {};
+    this._pathCounter = {};
+    this._prevFailTests = 0;
   }
 
   pathSeen(path, { numFailingTests }) {
@@ -56,11 +59,25 @@ class SpecFilesTracker {
       if (delta < 0) assertions_failed.dec(-delta);
     } else {
       this._pathsSeen[path] = {};
+      this._pathCounter[path] = 0;
       assert_files_seen.inc();
       if (numFailingTests > 0) assertions_failed.inc(numFailingTests);
       console.log('Path reported for the first time:', path);
     }
     this._pathsSeen[path].numFailingTests = numFailingTests;
+    
+    if (this._prevFailTests == this._pathsSeen[path].numFailingTests) {
+      // Tests for path has not increased
+      this._pathCounter[path]++;
+    }
+    this._prevFailTests = this._pathsSeen[path].numFailingTests
+
+    console.log("Path: " + path + " times, passed: ", this._pathCounter[path]);
+
+    if(this._pathCounter[path] >= 3) {
+      console.log("Test has passed more than 3 times:", path);
+      // Remove test from reruns?
+    }
   }
 
   modify(path) {
@@ -69,6 +86,11 @@ class SpecFilesTracker {
       if (err) throw err;
       //console.log('Modified', path);
     });
+  }
+
+  allowMod() {
+    allow_modification = true;
+    console.log("Allow modifications: ", allow_modification);
   }
 
   modifyAll() {
@@ -98,19 +120,57 @@ const tracker = new SpecFilesTracker();
  */
 class Reruns {
 
-  constructor({ tracker, intervalMs }) {
-    console.log('Activating reruns with interval (ms)', intervalMs);
-    this._intervalMs = intervalMs;
+  timeoutReached() {
+    console.log("Stopping reruns, timeout has been reached.");
+    console.log("Will not rerun until file modification");
+    this._doRerun = false;
+    // EXIT IMAGE OF DOCKER ASWELL?
+  }
+
+  constructor({ tracker }) {
+    this._rerunTime = 0;
+    this._timeout = 0;
+    this._doRerun = true;
+    if (fs.existsSync('./env.json')) {
+      this._rerunTime = Number(JSON.parse(fs.readFileSync('./env.json', 'utf8')).RERUN_TIME);
+      this._timeout = Number(JSON.parse(fs.readFileSync('./env.json', 'utf8')).TIMEOUT);
+    }
+    if (this._rerunTime != 0) {
+      console.log('Activating reruns with interval (ms)', this._rerunTime * 1000);
+    } else {
+      console.log('Interval reruns are turned off. Reruns will be run until all tests are OK');
+    }
+    setTimeout(() => {
+      tracker.allowMod();
+    }, 9000);
+
+    if(this._timeout != 0) {
+      setTimeout(() => {
+        this.timeoutReached();
+      }, this._timeout); 
+    }
+
+
+    this._intervalMs = this._rerunTime === 0 ? 10000 : this._rerunTime * 1000;
     this._timeout = null;
   }
 
   onRunComplete() {
     this._timeout !== null && clearTimeout(this._timeout);
-    if (!ASSERT_IS_DEV && RERUN_WAIT) {
+
+    if (!ASSERT_IS_DEV && (this._rerunTime > 0) && this._doRerun) {
+      console.log("Current reruntime in (s) is: ", this._intervalMs);
+      this._timeout = setTimeout(() => {
+        tracker.modifyAll();
+      }, this._intervalMs);
+      // Maybe move the else if to the if above.
+    } else if (assertions_failed.hashMap[''].value > 0 && this._doRerun) {
       this._timeout = setTimeout(() => {
         tracker.modifyAll();
       }, this._intervalMs);
     }
+    // This is where no reruns should happen?
+    console.log("Stopping reruns");
   }
 
 }


### PR DESCRIPTION
Since my commit directly on the branch created conflicts we decided to make this PR instead. Commit notes below can be seen as an explanation but basically the three final steps of development has been implemented in this branch. The X reruns does not have all the functionality yet but delay should. Timeout "has" the functionality but does not exit the image? properly when timeout has been reached.


**Commit notes:**
Timeout and delay should now be implemented for the cluster. Have not had enough time to see if it works properly. The logic should be there though. The image is not exited but there is a condition for where it should.

NOTE: Had to revert the previous version of this commit so it became a bit larger than expected. Now the rerun X times is in a dev-mode where after the tests pass a counter goes up, when the counter is larger than 3 it prints a message.